### PR TITLE
Fix possible KeyErrors and also added check to skip Windows machines.

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -65,7 +65,7 @@ def main():
 		conn = boto.ec2.connect_to_region(region.name)
 
 		for instance in conn.get_only_instances():
-			if instance.state == 'running':
+			if instance.state == 'running' and not instance.platform == 'windows':
 				if instance.launch_time not in instances:
 					instances[instance.launch_time] = []
 
@@ -84,14 +84,15 @@ def main():
 
 					for ami, user in AMIS_TO_USER.iteritems():
 						regexp = re.compile(ami)
-						if regexp.match(image.name):
+						if image and regexp.match(image.name):
 							amis[instance.image_id] = user
 							break
 
-					if instance.image_id not in amis:
+					if image and instance.image_id not in amis:
 						amis[instance.image_id] = None
 						sys.stderr.write('Can\'t lookup user for AMI \'' + image.name + '\', add a rule to the script\n')
-
+					else:
+						amis[instance.image_id] = None
 
 	for k in sorted(instances):
 		for instance in instances[k]:


### PR DESCRIPTION
Not sure if you are taking PRs for this repo, but I thought I would just submit some minor changes I made, because the script wouldn't work for me before.

What the PR Fixes (on my end):
- fixes an `Attribute: NoneType` error that can occur if `get_image()` returns nothing, there is no name attribute accessible. 
  Example:

```
ec2_conn.get_image(ec2_conn.get_all_instances()[3].instances[0].image_id).name
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-186-1b3c56025b4d> in <module>()
----> 1 ec2_conn.get_image(ec2_conn.get_all_instances()[3].instances[0].image_id).name

AttributeError: 'NoneType' object has no attribute 'name'

ec2_conn.get_image(ec2_conn.get_all_instances()[4].instances[0].image_id).name
Out[187]: u'ami-vpc-nat-1.1.0-
```
- add a check for `instance.platform == 'windows'` and skip accordingly, because there is no need to setup ssh config for Windows.
- `KeyError` trace backs if there was no key in the `amis` dict.

```
Traceback (most recent call last):
  File ".\aws-ssh-config.py", line 124, in <module>
    main()
  File ".\aws-ssh-config.py", line 115, in main
    if amis[instance.image_id] is not None:
KeyError: u'ami-abcdefghi-example'
```

Thanks for the useful script!  Works beautifully for me now, with these minor changes.

-Phil
