### PR TITLE
fixes keyerrors and checks for platform windows to skip accordingly

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -65,7 +65,7 @@ def main():
 		conn = boto.ec2.connect_to_region(region.name)
 
 		for instance in conn.get_only_instances():
-			if instance.state == 'running':
+			if instance.state == 'running' and not instance.platform == 'windows':
 				if instance.launch_time not in instances:
 					instances[instance.launch_time] = []
 
@@ -84,11 +84,11 @@ def main():
 
 					for ami, user in AMIS_TO_USER.iteritems():
 						regexp = re.compile(ami)
-						if regexp.match(image.name):
+						if image and regexp.match(image.name):
 							amis[instance.image_id] = user
 							break
 
-					if instance.image_id not in amis:
+					if image and instance.image_id not in amis:
 						amis[instance.image_id] = None
 						sys.stderr.write('Can\'t lookup user for AMI \'' + image.name + '\', add a rule to the script\n')
 
@@ -111,8 +111,11 @@ def main():
 			print 'Host ' + id
 			print '    HostName ' + ip
 
-			if amis[instance.image_id] is not None:
-				print '    User ' + amis[instance.image_id]
+			try:
+				if amis[instance.image_id] is not None:
+					print '    User ' + amis[instance.image_id]
+			except:
+				pass
 
 			print '    IdentityFile ~/.ssh/' + instance.key_name + '.pem'
 			print '    StrictHostKeyChecking no' # just for me, removing this is usually a good choice


### PR DESCRIPTION
Sorry for the confusion before.  This should not have the previous bug.  The bug was that the `User` portion was skipped entirely because of the `else` conditional in the other PR, this fixes that and remedies any Key errors by the `try except` block at the end where processing occurs.

Again sorry about the bad PR before, @gianlucaborello 

-Phil
