### PR TITLE
make profile accept string arguments

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -51,7 +51,7 @@ def main():
 	parser.add_argument('--tags', help='A comma-separated list of tag names to be considered for concatenation. If omitted, all tags will be used')
 	parser.add_argument('--region', action='store_true', help='Append the region name at the end of the concatenation')
 	parser.add_argument('--private', action='store_true', help='Use private IP addresses (public are used by default)')
-	parser.add_argument('--profile', action='store_true', help='specify aws credential profile to use')
+	parser.add_argument('--profile', help='specify aws credential profile to use')
 	args = parser.parse_args()
 
 	instances = {}


### PR DESCRIPTION
I don't believe the way you're specifying the profile argument actually works.  It doesn't for me.

```
$ python aws-ssh-config.py --tags Name --private --profile=sandbox
 usage: aws-ssh-config.py [-h] [--tags TAGS] [--region] [--private] [--profile]
                         [--prefix PREFIX]
aws-ssh-config.py: error: argument --profile: ignored explicit argument 'sandbox'
```

removing the action='store_true' seems to fix this.
