### PR TITLE
add a prefix that gets prepended to all hosts

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -52,6 +52,7 @@ def main():
 	parser.add_argument('--region', action='store_true', help='Append the region name at the end of the concatenation')
 	parser.add_argument('--private', action='store_true', help='Use private IP addresses (public are used by default)')
 	parser.add_argument('--profile', action='store_true', help='specify aws credential profile to use')
+	parser.add_argument('--prefix', default='', help='specify a prefix to prepend to all host names')
 	args = parser.parse_args()
 
 	instances = {}
@@ -111,7 +112,7 @@ def main():
 				counts_incremental[id] += 1
 				id += '-' + str(counts_incremental[id])
 
-			print 'Host ' + id
+			print 'Host ' + args.prefix + id
 			print '    HostName ' + ip
 
 			try:


### PR DESCRIPTION
in order to aid in tab completion, I like to have prefixes for my hosts.  This allows me to optionally provide a prefix, like the environment name, even when that isn't specifically a tag.
