### PR TITLE
Use private ip address if the instance does not have public ip

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -112,6 +112,11 @@ def main():
 			else:
 				if instance.ip_address:
 					ip = instance.ip_address
+				elif instance.private_ip_address:
+					ip = instance.private_ip_address
+				else:
+					sys.stderr.write('Cannot lookup ip address for instance %s, skipped it.' % instance.id)
+					continue
 
 			id = generate_id(instance, args.tags, args.region)
 


### PR DESCRIPTION
In current version, if the instance only has private IP then the **previous** instance ip will be used in config file. This will make it try to use the instance private ip and skip the instance if both are not available.
