### PR TITLE
Replace spaces in SSH key names with underscores

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -163,7 +163,7 @@ def main():
             else:
                 keydir = '~/.ssh/'
 
-            print '    IdentityFile ' + keydir + instance.key_name + '.pem'
+            print '    IdentityFile ' + keydir + instance.key_name.replace(' ', '_') + '.pem'
             if not args.no_identities_only:
                 # ensure ssh-agent keys don't flood when we know the right file to use
                 print '    IdentitiesOnly yes'


### PR DESCRIPTION
Since `ssh` complains about "garbage at end of line" when given IdentityFile paths with spaces inside, it would be easiest to replace the spaces as done elsewhere.