### PR TITLE
Added ProxyCommand for Bastion SSH Support

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -57,6 +57,7 @@ def main():
     parser.add_argument('--prefix', default='', help='Specify a prefix to prepend to all host names')
     parser.add_argument('--private', action='store_true', help='Use private IP addresses (public are used by default)')
     parser.add_argument('--profile', help='Specify AWS credential profile to use')
+    parser.add_argument('--proxy', default='', help='Specify a Bastion host to use with ProxyCommand')
     parser.add_argument('--region', action='store_true', help='Append the region name at the end of the concatenation')
     parser.add_argument('--ssh-key-name', default='', help='Override the ssh key to use')
     parser.add_argument('--strict-hostkey-checking', action='store_true', help='Do not include StrictHostKeyChecking=no in ssh config')
@@ -174,6 +175,8 @@ def main():
                 print '    IdentitiesOnly yes'
             if not args.strict_hostkey_checking:
                 print '    StrictHostKeyChecking no'
+            if args.proxy:
+                print '    ProxyCommand ssh ' + args.proxy + ' -W %h:%p'
             print
 
 


### PR DESCRIPTION
Updated your script to add optional ProxyCommand support for Bastion hosts using the --proxy argument.
