### PR TITLE
Added Postfix and Proxy for Multiple Bastion's and Accounts

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -57,6 +57,8 @@ def main():
     parser.add_argument('--prefix', default='', help='Specify a prefix to prepend to all host names')
     parser.add_argument('--private', action='store_true', help='Use private IP addresses (public are used by default)')
     parser.add_argument('--profile', help='Specify AWS credential profile to use')
+    parser.add_argument('--postfix', default='', help='Specify a postfix to append to all host names, Used to segregate hosts for use with different Bastion: --proxy')
+    parser.add_argument('--proxy', default='', help='Specify a Bastion host for ProxyCommand')
     parser.add_argument('--region', action='store_true', help='Append the region name at the end of the concatenation')
     parser.add_argument('--ssh-key-name', default='', help='Override the ssh key to use')
     parser.add_argument('--strict-hostkey-checking', action='store_true', help='Do not include StrictHostKeyChecking=no in ssh config')
@@ -150,6 +152,9 @@ def main():
             hostid = args.prefix + instance_id
             hostid = hostid.replace(' ', '_') # get rid of spaces
 
+            if args.postfix:
+                hostid + '_' + args.postfix
+
             print 'Host ' + hostid
             print '    HostName ' + ip_addr
 
@@ -174,6 +179,8 @@ def main():
                 print '    IdentitiesOnly yes'
             if not args.strict_hostkey_checking:
                 print '    StrictHostKeyChecking no'
+            if args.proxy:
+                print '    ProxyCommand ssh ' + proxy + ' -W %h:%p'
             print
 
 


### PR DESCRIPTION
Added Postfix, to allow to differentiate between Prod, Test, Sandbox, Dev, easily.

Added Proxy, to allow to add different Bastion Hosts per VPC / AWS Account.